### PR TITLE
prevent having executable stack

### DIFF
--- a/opa/opa_dwordcpy-i386.S
+++ b/opa/opa_dwordcpy-i386.S
@@ -78,3 +78,7 @@ hfi_dwordcpy:
 	mov %eax,%edi
 	mov %edx,%esi
 	ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/opa/opa_dwordcpy-x86_64-fast.S
+++ b/opa/opa_dwordcpy-x86_64-fast.S
@@ -71,3 +71,7 @@ hfi_dwordcpy:
 	rep
 	movsd
 	ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
Add .note.GNU-stack sections to objects compiled from assembly.
This allows libpsm2.so.2.0 to have non-executable stack.
