### PR TITLE
Fixes from building in Debian with -Werror=format-security

### DIFF
--- a/psm_context.c
+++ b/psm_context.c
@@ -316,7 +316,6 @@ psm2_error_t psmi_context_check_status(const psmi_context_t *contexti)
 	psmi_context_t *context = (psmi_context_t *) contexti;
 	struct hfi1_status *status =
 	    (struct hfi1_status *)context->ctrl->base_info.status_bufbase;
-	char *errmsg = NULL;
 
 	/* Fatal chip-related errors */
 	if (!(status->dev & HFI1_STATUS_CHIP_PRESENT) ||
@@ -333,11 +332,10 @@ psm2_error_t psmi_context_check_status(const psmi_context_t *contexti)
 						  errmsg_sp);
 			else {
 				if (status->dev & HFI1_STATUS_HWERROR)
-					errmsg = "Hardware error";
+					psmi_handle_error(context->ep, err, "Hardware error");
 				else
-					errmsg = "Hardware not found";
+					psmi_handle_error(context->ep, err, "Hardware not found");
 
-				psmi_handle_error(context->ep, err, errmsg);
 			}
 		}
 	}

--- a/psm_ep_connect.c
+++ b/psm_ep_connect.c
@@ -305,7 +305,7 @@ connect_fail:
 			}
 		}
 		errbuf[sizeof(errbuf) - 1] = '\0';
-		err = psmi_handle_error(ep, err, errbuf);
+		err = psmi_handle_error(ep, err, "%s", errbuf);
 	}
 
 fail:

--- a/psm_utils.c
+++ b/psm_utils.c
@@ -1547,7 +1547,7 @@ psmi_coreopt_ctl(const void *core_obj, int optname,
 
 fail:
 	/* Unrecognized/unknown option */
-	return psmi_handle_error(NULL, PSM2_PARAM_ERR, err_string);
+	return psmi_handle_error(NULL, PSM2_PARAM_ERR, "%s", err_string);
 }
 
 psm2_error_t psmi_core_setopt(const void *core_obj, int optname,


### PR DESCRIPTION
psm_ep_connect.c: In function '__psm2_ep_connect':
psm_ep_connect.c:308:3: error: format not a string literal and no format arguments [-Werror=format-security]
   err = psmi_handle_error(ep, err, errbuf);
   ^
psm_context.c: In function 'psmi_context_check_status':
psm_context.c:340:5: error: format not a string literal and no format arguments [-Werror=format-security]
     psmi_handle_error(context->ep, err, errmsg);
     ^
psm_utils.c: In function 'psmi_coreopt_ctl':
psm_utils.c:1550:2: error: format not a string literal and no format arguments [-Werror=format-security]
  return psmi_handle_error(NULL, PSM2_PARAM_ERR, err_string);
  ^
