### PR TITLE
compat: fix flag order to create a dependency from libpsm2-compat to …

### DIFF
--- a/compat/Makefile
+++ b/compat/Makefile
@@ -80,7 +80,7 @@ $(OUTDIR)/%.o: $(compat_build_dir)/%.c
 
 $(OUTDIR)/${COMPATLIB}.so.${MAJOR}: ${${COMPATLIB}-objs}
 	$(CC) $(BASECFLAGS) $(LINKER_SCRIPT) $(LDFLAGS) -Wl,-soname=${COMPATLIB}.so.${MAJOR} -shared \
-		 -L$(OUTDIR)/.. -lpsm2 -o $@ ${${COMPATLIB}-objs}
+		 -L$(OUTDIR)/.. -o $@ ${${COMPATLIB}-objs} -lpsm2
 
 clean:
 	@if [ -d $(OUTDIR) ]; then \


### PR DESCRIPTION
…libpsm2

The flag being placed before the object file has no effect.
ldd /usr/lib64/libpsm_infinipath.so.1
	linux-vdso.so.1 (0x00007ffd9e1de000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f1c4b8c6000)
	/lib64/ld-linux-x86-64.so.2 (0x000055a5e0c98000)

Placing it after the obj files creates a dependency as they reference PSM2 symbols
ldd /usr/lib64/libpsm_infinipath.so.1
	linux-vdso.so.1 (0x00007fff6bdfd000)
	libpsm2.so.2 => /usr/lib64/libpsm2.so.2 (0x00007fe294dd9000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fe294a36000)
	librt.so.1 => /lib64/librt.so.1 (0x00007fe29482e000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fe294610000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007fe29440c000)
	libuuid.so.1 => /usr/lib64/libuuid.so.1 (0x00007fe294207000)
	/lib64/ld-linux-x86-64.so.2 (0x0000556052910000)

Signed-off-by: Nicolas Morey-Chaisemartin <NMoreyChaisemartin@suse.com>