### PR TITLE
Remove an excessive abs for the usigned value

### DIFF
--- a/opa/opa_time.c
+++ b/opa/opa_time.c
@@ -69,6 +69,16 @@
 
 #include "opa_user.h"
 
+#ifdef min
+#undef min
+#endif
+#define min(a, b) ((a) < (b) ? (a) : (b))
+
+#ifdef max
+#undef max
+#endif
+#define max(a, b) ((a) > (b) ? (a) : (b))
+
 /* init the cycle counter to picosecs/cycle conversion automatically */
 /* at program startup, if it's using timing functions. */
 static void init_picos_per_cycle(void) __attribute__ ((constructor));
@@ -224,6 +234,7 @@ static uint32_t hfi_timebase_from_cpuinfo(uint32_t old_pico_per_cycle)
 {
 	/* we only validate once */
 	uint32_t new_pico_per_cycle = old_pico_per_cycle;
+	uint32_t max_bet_new_old_pico, min_bet_new_old_pico;
 
 	char hostname[80];
 	gethostname(hostname, 80);
@@ -261,9 +272,10 @@ static uint32_t hfi_timebase_from_cpuinfo(uint32_t old_pico_per_cycle)
 			goto fail;
 	}
 #endif
-
+	max_bet_new_old_pico = max(new_pico_per_cycle, old_pico_per_cycle);
+	min_bet_new_old_pico = min(new_pico_per_cycle, old_pico_per_cycle);
 	/* If there's no change (within a small range), just return the old one */
-	if (abs(new_pico_per_cycle - old_pico_per_cycle) < 5)
+	if ((max_bet_new_old_pico - min_bet_new_old_pico) < 5)
 		return old_pico_per_cycle;
 
 	if (hfi_timebase_isvalid(new_pico_per_cycle)) {


### PR DESCRIPTION
I've submitted the issue 01org/psm#18 to the psm
Does this make sense? The result is always unsigned value, there is no need to invoke `abs` for that

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>