### PR TITLE
Fix spelling errors in strings.

### DIFF
--- a/psm_ep_connect.c
+++ b/psm_ep_connect.c
@@ -132,7 +132,7 @@ __psm2_ep_connect(psm2_ep_t ep, int num_of_epid, psm2_epid_t const *array_of_epi
 			if (psmi_epid_version(array_of_epid[j]) >
 						 PSMI_EPID_VERSION) {
 					psmi_handle_error(PSMI_EP_NORETURN, PSM2_INTERNAL_ERR,
-					  " Unkown version of EPID - %"PRIu64" \n"
+					  " Unknown version of EPID - %"PRIu64" \n"
 					  "Please upgrade PSM2 or set PSM2_ADDR_FMT=1 in the environment to force EPID version 1 \n",
 					  psmi_epid_version(array_of_epid[j]));
 			}

--- a/ptl_ips/ips_path_rec.c
+++ b/ptl_ips/ips_path_rec.c
@@ -659,7 +659,7 @@ MOCKABLE(ips_ibta_init)(struct ips_proto *proto)
 		_HFI_PRDBG("Static path selection: Base LID\n");
 
 	psmi_getenv("PSM2_DISABLE_CCA",
-		    "Disable use of Congestion Control Architecure (CCA) [enabled] ",
+		    "Disable use of Congestion Control Architecture (CCA) [enabled] ",
 		    PSMI_ENVVAR_LEVEL_USER, PSMI_ENVVAR_TYPE_UINT,
 		    (union psmi_envvar_val)0, &disable_cca);
 	if (disable_cca.e_uint)


### PR DESCRIPTION
Two spelling errors were called out by lintian during
the debian build:

 * Unkown
 * Architecure

Fixes #19 