### PR TITLE
fix gcc8 compilation error

### DIFF
--- a/psm_utils.c
+++ b/psm_utils.c
@@ -945,7 +945,7 @@ struct psmi_faultinj_spec *psmi_faultinj_getspec(char *spec_name, int num,
 		union psmi_envvar_val env_fi;
 		char fvals_str[128];
 		char fname[128];
-		char fdesc[256];
+		char fdesc[280];
 
 		snprintf(fvals_str, sizeof(fvals_str) - 1, "%d:%d:1", num,
 			 denom);


### PR DESCRIPTION
Compiling with gcc 8.0.1 fails with:
/home/abuild/rpmbuild/BUILD/libpsm2-10.3.37/psm_utils.c: In function 'psmi_faultinj_getspec':
/home/abuild/rpmbuild/BUILD/libpsm2-10.3.37/psm_utils.c:985:59: error: '%s' directive output may be truncated writing up to 127 bytes into a region of size between 110 and 237 [-Werror=format-truncation=]
   snprintf(fdesc, sizeof(fdesc) - 1, "Fault Injection %s <%s>",
                                                           ^~
     fname, fvals_str);
            ~~~~~~~~~
In file included from /usr/include/stdio.h:862,
                 from /usr/include/malloc.h:24,
                 from /home/abuild/rpmbuild/BUILD/libpsm2-10.3.37/psm_utils.c:55:
/usr/include/bits/stdio2.h:64:10: note: '__builtin___snprintf_chk' output between 20 and 274 bytes into a destination of size 255
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [Makefile:522: /home/abuild/rpmbuild/BUILD/libpsm2-10.3.37/build_release/psm_utils.o] Error 1

This increases the target buffer size to remove the error

Signed-off-by: Nicolas Morey-Chaisemartin <NMoreyChaisemartin@suse.com>