### PR TITLE
Issue #30: fix snprintf truncation warning in psm_faultinj_spec

### DIFF
--- a/psm_utils.c
+++ b/psm_utils.c
@@ -945,7 +945,7 @@ struct psmi_faultinj_spec *psmi_faultinj_getspec(char *spec_name, int num,
 		union psmi_envvar_val env_fi;
 		char fvals_str[128];
 		char fname[128];
-		char fdesc[256];
+		char fdesc[32 + sizeof(fvals_str) + sizeof(fname)];
 
 		snprintf(fvals_str, sizeof(fvals_str) - 1, "%d:%d:1", num,
 			 denom);


### PR DESCRIPTION
Expand the size of fdesc buffer declared in psm_util.c:psm_faultinj_spec.