### PR TITLE
hfi_dwordcpy: Add CET markup to the x86 assembler implementations

### DIFF
--- a/opa/opa_dwordcpy-i386.S
+++ b/opa/opa_dwordcpy-i386.S
@@ -53,6 +53,10 @@
 
 /* Copyright (c) 2003-2014 Intel Corporation. All rights reserved. */
 
+#ifdef __CET__
+#include <cet.h>
+#endif
+
  	.globl hfi_dwordcpy
 	.file	"opa_dword32cpy.S"
 	.text
@@ -61,6 +65,9 @@ hfi_dwordcpy:
 	// standard C calling convention, args on stack
         // does not return any value
 	.type	hfi_dwordcpy, @function
+#ifdef _CET_ENDBR
+	_CET_ENDBR
+#endif
 	// save caller-saved regs
 	mov    %edi,%eax
 	mov    %esi,%edx

--- a/opa/opa_dwordcpy-x86_64-fast.S
+++ b/opa/opa_dwordcpy-x86_64-fast.S
@@ -53,6 +53,10 @@
 
 /* Copyright (c) 2003-2014 Intel Corporation. All rights reserved. */
 
+#ifdef __CET__
+#include <cet.h>
+#endif
+
  	.globl hfi_dwordcpy
 	.file	"opa_dwordcpy-x86_64-fast.S"
 	.text
@@ -61,6 +65,9 @@
         // does not return any value
 hfi_dwordcpy:
 	.type	hfi_dwordcpy, @function
+#ifdef _CET_ENDBR
+	_CET_ENDBR
+#endif
 	movl %edx,%ecx
 	shrl $1,%ecx
 	andl $1,%edx


### PR DESCRIPTION
Note that the `_CET_ENDBR ` instruction is only needed if the function is ever called from a different shared object. I did not see any `.hidden` or visibility attribute, so I assumed that this might be the case, and added the instruction just in case.