### PR TITLE
Fix uninitialized cuda_hostbuf_used in ips_proto_mq_{send,isend}

### DIFF
--- a/ptl_ips/ips_proto_mq.c
+++ b/ptl_ips/ips_proto_mq.c
@@ -704,6 +704,7 @@ ips_proto_mq_isend(psm2_mq_t mq, psm2_epaddr_t mepaddr, uint32_t flags_user,
 
 #ifdef PSM_CUDA
 	req->is_buf_gpu_mem = psmi_cuda_is_buffer_gpu_mem((void*)ubuf);
+	req->cuda_hostbuf_used = 0;
 	if (req->is_buf_gpu_mem) {
 		psmi_cuda_set_attr_sync_memops((void*)ubuf);
 		if (psmi_cuda_is_needed_rendezvous(proto, len))
@@ -1031,6 +1032,7 @@ ips_proto_mq_send(psm2_mq_t mq, psm2_epaddr_t mepaddr, uint32_t flags,
 			return err;
 
 #ifdef PSM_CUDA
+		req->cuda_hostbuf_used = 0;
 		if (gpu_mem) {
 			req->is_buf_gpu_mem = 1;
 		} else


### PR DESCRIPTION
The value is read in ips_proto_mq_eager_complete to determine if prefetched buffers from sendreq_prefetch must be reclaimed. If cuda_hostbuf_used is uninitialized, the value might be different from 0 which leads to crashes if sendreq_prefetch hasn't been set up correctly.

From what I can see there are 4 possible call stacks that lead to that function:
1&2) Via ips_ptl_mq_eager which is called from both ips_proto_mq_{send,isend} if len <= mq->hfi_thresh_rv. Note that this doesn't use prefetch buffers, so I think it's correct to set cuda_hostbuf_used = 0.
3) In ips_proto_mq_isend if len <= flow->frag_size. Again this doesn't use prefetch buffers, so the default for the request in ips_proto_mq_isend can be cuda_hostbuf_used = 0.
4) ips_proto_mq_push_rts_data which is involved if len > mq->hfi_thresh_rv. In that case ips_ptl_mq_rndv correctly sets cuda_hostbuf_used = {0,1}.