### PR TITLE
Add missing extern keywords

### DIFF
--- a/ptl_am/ptl_fwd.h
+++ b/ptl_am/ptl_fwd.h
@@ -57,7 +57,7 @@
 #define _PTL_FWD_AMSH_H
 
 /* Symbol in am ptl */
-struct ptl_ctl_init psmi_ptl_amsh;
+extern struct ptl_ctl_init psmi_ptl_amsh;
 
 extern int psmi_shm_mq_rv_thresh;
 

--- a/ptl_ips/ptl_fwd.h
+++ b/ptl_ips/ptl_fwd.h
@@ -61,7 +61,7 @@ typedef struct ips_epaddr ips_epaddr_t;
 typedef struct ips_msgctl ips_msgctl_t;
 
 /* Symbol in ips ptl */
-struct ptl_ctl_init psmi_ptl_ips;
+extern struct ptl_ctl_init psmi_ptl_ips;
 
-struct ptl_ctl_rcvthread psmi_ptl_ips_rcvthread;
+extern struct ptl_ctl_rcvthread psmi_ptl_ips_rcvthread;
 #endif /* _PTL_FWD_IPS_H */

--- a/ptl_self/ptl_fwd.h
+++ b/ptl_self/ptl_fwd.h
@@ -57,6 +57,6 @@
 #define _PTL_FWD_SELF_H
 
 /* Symbol in am ptl */
-struct ptl_ctl_init psmi_ptl_self;
+extern struct ptl_ctl_init psmi_ptl_self;
 
 #endif


### PR DESCRIPTION
Starting from the upcoming GCC release 10, the default of -fcommon option will change to -fno-common:
In C, global variables with multiple tentative definitions will result in linker errors.
Global variable accesses are also more efficient on various targets.

This fixes compilations errors with -fno-common enabled

Signed-off-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>