### PR TITLE
Fix detection of support for GPUDirect

### DIFF
--- a/psm.c
+++ b/psm.c
@@ -246,6 +246,8 @@ int psmi_cuda_initialize()
 	/* Check if all devices support Unified Virtual Addressing. */
 	PSMI_CUDA_CALL(cuDeviceGetCount, &num_devices);
 
+	device_support_gpudirect = 1;
+
 	for (dev = 0; dev < num_devices; dev++) {
 		CUdevice device;
 		PSMI_CUDA_CALL(cuDeviceGet, &device, dev);
@@ -265,9 +267,7 @@ int psmi_cuda_initialize()
 				&major,
 				CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
 				device);
-		if (major >= 3)
-			device_support_gpudirect = 1;
-		else {
+		if (major < 3) {
 			device_support_gpudirect = 0;
 			_HFI_INFO("Device %d does not support GPUDirect RDMA (Non-fatal error) \n", dev);
 		}


### PR DESCRIPTION
The previous code would have considered the compute capablity of the
last device. It makes more sense to require _all_ GPUs to support
GPUDirect in order to use it.