### PR TITLE
fix syntax errors in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ INCLUDES += -I$(top_srcdir) -I$(top_srcdir)/ptl_ips -I$(OUTDIR)
 
 ifneq (x86_64,$(arch))
    ifneq (i386,$(arch))
-      $(error Unsupported architecture $(arch))
+      anerr := $(error Unsupported architecture $(arch))
    endif
 endif
 
@@ -164,7 +164,7 @@ nthreads := $(shell echo $$(( `nproc` * 2 )) )
 # The DISTRO variable is used subsequently for variable
 # behaviors of the 3 distros.
 
-DISTRO := $(shell . /etc/os-release; if [[ "$$ID" == "sle_hpc" ]]; then ID="sles"; fi; echo $$ID)
+DISTRO := $(shell . /etc/os-release; if [ "$$ID" = "sle_hpc" ]; then ID="sles"; fi; echo $$ID)
 
 # By default the following two variables have the following values:
 LIBPSM2_COMPAT_CONF_DIR := /etc

--- a/buildflags.mak
+++ b/buildflags.mak
@@ -118,13 +118,13 @@ ifneq (icc,${CC})
 		RET := $(shell echo "int main() {}" | ${CC} ${MAVX2} -E -dM -xc - 2>&1 | grep -q AVX2 ; echo $$?)
 	else
 		RET := $(shell echo "int main() {}" | ${CC} ${MAVX2} -E -dM -xc - 2>&1 | grep -q AVX ; echo $$?)
-		$(warning ***NOTE TO USER**** Disabling AVX2 will harm performance)
+                anerr := $(warning ***NOTE TO USER**** Disabling AVX2 will harm performance)
 	endif
 
 	ifeq (0,${RET})
 		BASECFLAGS += ${MAVX2}
 	else
-		$(error Compiler does not support ${MAVX2} )
+		anerr := $(error Compiler does not support ${MAVX2} )
 	endif
 else
 		BASECFLAGS += ${MAVX2}
@@ -138,7 +138,7 @@ ifneq (,${PSM_AVX512})
 		ifeq (0,${RET})
 			BASECFLAGS += -mavx512f
 		else
-			$(error Compiler does not support AVX512 )
+			anerr := $(error Compiler does not support AVX512 )
 		endif
 		BASECFLAGS += -DPSM_AVX512
 	endif
@@ -203,7 +203,7 @@ else
 		BASECFLAGS += -funwind-tables -Wno-strict-aliasing -Wformat-security
 	else
 		ifneq (${CCARCH},gcc4)
-			$(error Unknown compiler arch "${CCARCH}")
+			anerr := $(error Unknown compiler arch "${CCARCH}")
 		endif # gcc4
 	endif # gcc
 endif # icc


### PR DESCRIPTION
Calls to $(error) or $(warning) that are indented with tabs generate
gmake "recipe commences before first target" errors.   example: the
warning call on line 121 of buildflags.mak does this:

<pre>
% make PSM_DISABLE_AVX2=yes
/tmp/bob/opa-psm2/buildflags.mak:121: *** recipe commences before first target.  Stop.
%
</pre>

To resolve you can delete the spaces, turn the tabs to spaces, or
prefix error/warning calls with an assignment ("anerr :=").  Since
the "anerr" was already in use in other places in psm2, apply that fix
to the rest of the Makefile and buildflags.mak.

Also, the definition of DISTRO assumes /bin/sh is bash and uses
the bash "[[ a == b ]]" syntax.  This generates a shell error
every time you run make if /bin/sh isn't bash.  For example,
on an ubuntu box:

<pre>
% make
/bin/sh: 1: [[: not found
...
</pre>

Resolve this by converting "[[ a == b ]]" to the more portable
"[ a = b ]" format.   This resolves opa-psm2 issue #55 ...