### PR TITLE
Allow PSM2 to work with "self,shm" devices without omnipath hardware

### DIFF
--- a/psm2_hal.c
+++ b/psm2_hal.c
@@ -379,6 +379,20 @@ int psmi_hal_initialize(void)
 	return -PSM_HAL_ERROR_INIT_FAILED;
 }
 
+/* psmi_hal_initialize_null */
+void psmi_hal_initialize_null(void)
+{
+	static struct _psmi_hal_instance nullhal = {
+		.type = PSM_HAL_INSTANCE_NULL,
+		.description = "NULL HAL (hardware disabled)",
+		.hfi_name = "null",
+		.hfi_sys_class_path = "/dev/null",
+		.params = {0}
+	};
+
+	psmi_hal_current_hal_instance = &nullhal;
+}
+
 int psmi_hal_finalize(void)
 {
 	struct _psmi_hal_instance *p = psmi_hal_current_hal_instance;

--- a/psm2_hal.h
+++ b/psm2_hal.h
@@ -75,6 +75,7 @@ typedef enum
 	PSM_HAL_INSTANCE_GEN2    =  2,
 	PSM_HAL_INSTANCE_GEN3    =  3,
 
+	PSM_HAL_INSTANCE_NULL	 = 98,
 #ifdef PSM2_MOCK_TESTING
 	PSM_HAL_INSTANCE_MOCK    = 99,
 #endif
@@ -701,6 +702,7 @@ void psmi_hal_register_instance(psmi_hal_instance_t *);
     INSTANCES are registered, or PSM_HAL_ERROR_INIT_FAILED when
     another failure has occured during initialization. */
 int psmi_hal_initialize(void);
+void psmi_hal_initialize_null(void);
 
 int psmi_hal_finalize(void);
 

--- a/psm_ep.c
+++ b/psm_ep.c
@@ -89,9 +89,6 @@ static psm2_error_t psmi_ep_open_device(const psm2_ep_t ep,
  * hfi.
  */
 
-static psm2_error_t psmi_parse_devices(int devices[PTL_MAX_INIT],
-				      const char *devstr);
-static int psmi_device_is_enabled(const int devices[PTL_MAX_INIT], int devid);
 int psmi_ep_device_is_enabled(const psm2_ep_t ep, int devid);
 
 psm2_error_t __psm2_ep_num_devunits(uint32_t *num_units_o)
@@ -1491,7 +1488,6 @@ fail:
 
 /* Get a list of PTLs we want to use.  The order is important, it affects
  * whether node-local processes use shm or ips */
-static
 psm2_error_t
 psmi_parse_devices(int devices[PTL_MAX_INIT], const char *devstring)
 {
@@ -1562,7 +1558,6 @@ fail:
 
 }
 
-static
 int psmi_device_is_enabled(const int devid_enabled[PTL_MAX_INIT], int devid)
 {
 	int i;

--- a/psm_ep.h
+++ b/psm_ep.h
@@ -236,4 +236,9 @@ struct psm2_epaddr {
 	PSMI_PROFILE_UNBLOCK();						\
 } while (0)
 
+
+psm2_error_t psmi_parse_devices(int devices[PTL_MAX_INIT],
+				      const char *devstr);
+int psmi_device_is_enabled(const int devices[PTL_MAX_INIT], int devid);
+
 #endif /* _PSMI_EP_H */


### PR DESCRIPTION
Both PSM and PSM2 allow you to specify the devices you want to
configure (i.e. the ptls) using the PSM_DEVICES and PSM2_DEVICES
environment variables.  For example, setting the variable to
"self,shm" tells the library to configure the self and shared
memory PTL layers, but not the IPS layer that requires PSM/PSM2
infiniband HCAs.  This allows users to do some basic PSM/PSM2
CI testing (e.g. with travis) without having to have to have
infiniband hardware in the CI testing infrastructure.

Unfortunately, this feature is currently broken in PSM2 due
to the introduction of the hal layer.  psm2_init() always
calls psmi_hal_initialize().   psmi_hal_initialize()
will fail if infiniband hardware is not present, resulting
in psm2_init() failing with a "PSM Unresolved internal error"
even if PSM2_DEVICES is set to "self,shm" ...

This patch resolves this issue and allows PSM2 to operate
with PSM2_DEVICES set to "self,shm" ...

To do this, we have psm2_init() examine PSM2_DEVICES and
only call psmi_hal_initialize() if the PTL_DEVID_IPS device
is in use.   If psm2_init() determines that PTL_DEVID_IPS is
not needed, then we install a "null" hal into
"psmi_hal_current_hal_instance" using a new hal API call
psmi_hal_initialize_null().

We make psm_ep.c's psmi_parse_devices() and psmi_device_is_enabled()
non-static so that psm2_init() can call them from psm.c

with the fix on a node without PSM2 hardware:
<pre>
int main(int argc, char **argv) {
  int ver_major, ver_minor;
  psm2_error_t err;

  ver_major = PSM2_VERNO_MAJOR;
  ver_minor = PSM2_VERNO_MINOR;
  err = psm2_init(&ver_major, &ver_minor);
  if (err == PSM2_OK) {
    printf("psm2_init: OK, version is %d.%d\n", ver_major, ver_minor);
  } else {
    printf("psm2_init: ERR %s\n", psm2_error_get_string(err));
  }
  exit(0);
}
</pre>

results in:
<pre>
% ./p-test
psm2_init: ERR PSM Unresolved internal error
% env PSM2_DEVICES=self,shm ./p-test
psm2_init: OK, version is 2.2
%
</pre>

Other PSM2 calls work over shm with this (e.g. irecv, isend, ipeek, test,...)
